### PR TITLE
Lat/Lon outlier removal during gridding

### DIFF
--- a/gbtpipe/Gridding.py
+++ b/gbtpipe/Gridding.py
@@ -489,7 +489,7 @@ def griddata(filelist,
         if (((w.wcs.ctype[0]).split('-'))[0] !=
             ((s[0]['CTYPE1']).split('-'))[0]):
             warnings.warn('Spectral data not in same frame as template header')
-            #eulerFlag = True
+            eulerFlag = True
 
     outCube = np.zeros((int(naxis3), int(naxis2), int(naxis1)),dtype=dtype)
     outWts = np.zeros((int(naxis2), int(naxis1)),dtype=dtype)

--- a/gbtpipe/Gridding.py
+++ b/gbtpipe/Gridding.py
@@ -306,6 +306,7 @@ def griddata(filelist,
              outdir=None, 
              outname=None,
              dtype=np.float64,
+	     flagSpatialOutlier=False
              **kwargs):
 
     """Gridding code for GBT spectral scan data produced by pipeline.
@@ -393,6 +394,11 @@ def griddata(filelist,
     outname : str
         Output directory file name.  Defaults to object name in the
         original spectra.
+
+    flagSpatialOutlier : bool
+        Setting to True will remove scans with positions far outside the 
+	bounding box of the regular scan pattern. Used to catch instances
+	where the encoder records erroneous positions. 
 
     Returns
     -------
@@ -507,11 +513,12 @@ def griddata(filelist,
     for thisfile in filelist:
         ctr += 1
         s = fits.open(thisfile)
-	# Remove outliers in Lat/Lon space
-	f = np.where(is_outlier(s[1].data['CRVAL2'], thresh=1.5)!=True)
-	s[1].data = s[1].data[f]
-	f = np.where(is_outlier(s[1].data['CRVAL3'], thresh=1.5)!=True)
-	s[1].data = s[1].data[f]
+	if flagSpatialOutlier:
+		# Remove outliers in Lat/Lon space
+		f = np.where(is_outlier(s[1].data['CRVAL2'], thresh=1.5)!=True)
+		s[1].data = s[1].data[f]
+		f = np.where(is_outlier(s[1].data['CRVAL3'], thresh=1.5)!=True)
+		s[1].data = s[1].data[f]
         print("Now processing {0}".format(thisfile))
         print("This is file {0} of {1}".format(ctr, len(filelist)))
         if len(s[1].data) == 0:

--- a/gbtpipe/Gridding.py
+++ b/gbtpipe/Gridding.py
@@ -109,16 +109,7 @@ def mad1d(x):
 def baselineSpectrum(spectrum, order=1, baselineIndex=()):
     x = np.linspace(-1, 1, len(spectrum))
     coeffs = legendre.legfit(x[baselineIndex], spectrum[baselineIndex], order)
-    #import matplotlib.pyplot as plt
-    #if 1 > 0:
-	#print max(y)/noiserms
-    #	plt.plot(x,legendre.legval(x, coeffs), color='red') #Fitted baseline
-    #	plt.plot(x,spectrum, color='blue') # original spectrum
-    #	plt.plot(x[baselineIndex], spectrum[baselineIndex], color='green') # channels used for fit
-    #	plt.show()
-    #spectrum -= legendre.legval(x, coeffs)
-    #plt.plot(x,spectrum, color='blue')
-    #plt.show()
+    spectrum -= legendre.legval(x, coeffs)
     return(spectrum)
 
 
@@ -588,8 +579,6 @@ def griddata(filelist,
             # Generate Baseline regions
             baselineIndex = np.concatenate([nuindex[ss]
                                             for ss in baselineRegion])
-	    #print np.shape(baselineIndex)
-	    #print baselineIndex
 
             specData = spectrum['DATA']
             if spectrum['OBJECT'] == 'VANE' or spectrum['OBJECT'] == 'SKY':


### PR DESCRIPTION
This is my attempt to remove scans with lat/lon values that deviate significantly from the normal tile boundaries.  I pulled a MAD-based outlier detection function from another Github page and applied it to the tile data prior to gridding.  I have tuned the z-score threshold parameter to remove the outliers that I identified by eye in W3, but I think that threshold will be applicable to all tiles.

Some results before (left panel) and after (right panel) this implementation are shown below:

<img width="720" alt="w3_outlier" src="https://user-images.githubusercontent.com/16109704/36825581-1f3eff5c-1cbd-11e8-8791-ecf7bb42d70c.png">
