### PR TITLE
Flagging enhancements

### DIFF
--- a/gbtpipe/ArgusCal.py
+++ b/gbtpipe/ArgusCal.py
@@ -247,7 +247,7 @@ def RowEnds(integrations, off_frac=0.25):
 
 def calscans(inputdir, start=82, stop=105, refscans=[80],
              badscans=[],
-             outdir=None, log=None, loglevel='wasrning',
+             outdir=None, log=None, loglevel='warning',
              OffSelector=RowEnds, OffType='linefit',
              verbose=True, suffix='', **kwargs):
     """

--- a/gbtpipe/ArgusCal.py
+++ b/gbtpipe/ArgusCal.py
@@ -246,7 +246,8 @@ def RowEnds(integrations, off_frac=0.25):
     return(OffMask)
 
 def calscans(inputdir, start=82, stop=105, refscans=[80],
-             outdir=None, log=None, loglevel='warning',
+             badscans=[],
+             outdir=None, log=None, loglevel='wasrning',
              OffSelector=RowEnds, OffType='linefit',
              verbose=True, suffix='', **kwargs):
     """
@@ -314,6 +315,8 @@ def calscans(inputdir, start=82, stop=105, refscans=[80],
     # Assume spacing in uniform between start and stop
     cl_params.mapscans = list(np.linspace(start,stop,
                                           stop-start+1).astype('int'))
+    for bad in badscans:
+        cl_params.mapscans.remove(bad)
     cl_params.refscans = refscans
     
     

--- a/gbtpipe/Baseline.py
+++ b/gbtpipe/Baseline.py
@@ -4,8 +4,12 @@ from scipy.optimize import least_squares as lsq
 from spectral_cube import SpectralCube
 import astropy.units as u
 import astropy.utils.console as console
-import pyspeckit.spectrum.models.ammonia_constants as acons
-
+try:
+    import pyspeckit.spectrum.models.ammonia_constants as acons
+except ModuleNotFoundError:
+    import warnings
+    warnings.warn('Module pyspeckit not found.' +
+                  'Ammonia baseline routines will fail.')
 
 def ammoniaLoss(fullcoefs, y, x, v, noise, line='oneone', chthrow=None):
     # Define coeffs as
@@ -177,7 +181,7 @@ def robustBaseline(y, baselineIndex, blorder=1, noiserms=None):
     opts = lsq(legendreLoss, np.zeros(blorder + 1), args=(y[baselineIndex],
                                                           x[baselineIndex],
                                                           noiserms),
-               loss='arctan')
+               loss='soft_l1')
 
     return y - legendre.legval(x, opts.x)
 

--- a/gbtpipe/Gridding.py
+++ b/gbtpipe/Gridding.py
@@ -375,6 +375,9 @@ def griddata(filelist,
         radiometer formula.  Note that these estimators are outlier
         robust.
 
+    rippleThresh: float
+        Threshold for ripple flagging relative to RMS.  Default = 2
+
     flagSpike : bool
         Setting to True sets spikes to zero to avoid corrupting data
         before frequency shifting.


### PR DESCRIPTION
These are fixes to #17 , #18

First: `flagSpike` now works as intended and `blankSpike` has been removed from the call signature of `gbtpipe.griddata`. Thresholding is adjusted with the `spikeThresh` parameter.

`rippleThresh` is now an adjustable keyword that used to be set to 2, which is now the default value.

Before spike flagging:
<img width="611" alt="PreFlag" src="https://user-images.githubusercontent.com/1139910/60550949-e5017580-9ce6-11e9-8688-5f96581a7961.png">

After spike flagging:
<img width="606" alt="PostFlag" src="https://user-images.githubusercontent.com/1139910/60550957-ea5ec000-9ce6-11e9-81f4-a44520fc5c86.png">

cc: @aakepley 