### PR TITLE
fix for subdirectory creation

### DIFF
--- a/gbtpipe/Gridding.py
+++ b/gbtpipe/Gridding.py
@@ -573,6 +573,9 @@ def griddata(filelist,
 
         if plotTimeSeries:
             plt.switch_backend('agg')
+            # fix for subdirectories. 
+            if not os.access(outdir, os.W_OK):
+                os.mkdir(outdir)
             if not os.access(outdir +'/' + plotsubdir, os.W_OK):
                 os.mkdir(outdir + '/' + plotsubdir)
             vmin=np.nanpercentile(s[1].data['DATA'],15)


### PR DESCRIPTION
Added a check that the top level directory exists and create it if is doesn't. Evidently os.mkdir doesn't do nesting. Might be smarter python way to do this.